### PR TITLE
fix: duplicated test function

### DIFF
--- a/velero-plugin-for-microsoft-azure/object_store_test.go
+++ b/velero-plugin-for-microsoft-azure/object_store_test.go
@@ -167,31 +167,3 @@ func TestGetBlockSize(t *testing.T) {
 	size = getBlockSize(logger, config)
 	assert.Equal(t, 1048570, size)
 }
-
-func TestGetBlockSize(t *testing.T) {
-	logger := logrus.New()
-	config := map[string]string{}
-	// not specified
-	size := getBlockSize(logger, config)
-	assert.Equal(t, defaultBlockSize, size)
-
-	// invalid value specified
-	config[blockSizeConfigKey] = "invalid"
-	size = getBlockSize(logger, config)
-	assert.Equal(t, defaultBlockSize, size)
-
-	// value < 0 specified
-	config[blockSizeConfigKey] = "0"
-	size = getBlockSize(logger, config)
-	assert.Equal(t, defaultBlockSize, size)
-
-	// value > max size specified
-	config[blockSizeConfigKey] = "1048576000"
-	size = getBlockSize(logger, config)
-	assert.Equal(t, maxBlockSize, size)
-
-	// valid value specified
-	config[blockSizeConfigKey] = "1048570"
-	size = getBlockSize(logger, config)
-	assert.Equal(t, 1048570, size)
-}


### PR DESCRIPTION
Fix for
```sh
$ go mod vendor && go test -v ./...
?   	github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/hack/cp-plugin	[no test files]
# github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/velero-plugin-for-microsoft-azure [github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/velero-plugin-for-microsoft-azure.test]
velero-plugin-for-microsoft-azure/object_store_test.go:171:6: TestGetBlockSize redeclared in this block
	velero-plugin-for-microsoft-azure/object_store_test.go:143:6: other declaration of TestGetBlockSize
FAIL	github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/velero-plugin-for-microsoft-azure [build failed]
FAIL

```