### PR TITLE
feat: Add FIPS 140-3 support with GOFIPS140 v1.26.0

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,9 +1,17 @@
+# FIPS 140-3 Compliance Configuration:
+# - GOFIPS140=v1.26.0: Embeds Go's native FIPS 140-3 cryptographic module (certified A6650)
+# - Plugin processes inherit GODEBUG=fips140=on from parent Velero process
+# - CGO_ENABLED=0: GOFIPS140 is pure Go, no CGO/OpenSSL dependencies required
+#   (see https://go.dev/blog/fips140 - "written in pure Go (and Go assembly)")
+# - Required to match Velero's FIPS capabilities for regulated OpenShift deployments
+
 FROM --platform=$BUILDPLATFORM quay.io/konveyor/builder:ubi9-latest AS builder
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 
 ENV GOPATH=$APP_ROOT
+ENV GOFIPS140=v1.26.0
 
 COPY . $APP_ROOT/src/velero-plugin-for-microsoft-azure
 


### PR DESCRIPTION
## Summary

Add native Go FIPS 140-3 cryptographic module support to velero-plugin-for-microsoft-azure for OpenShift OADP 1.5.

## Changes

- Add `GOFIPS140=v1.26.0` build environment variable
- Keep `CGO_ENABLED=0` (GOFIPS140 is pure Go, no CGO needed)
- Add inline documentation explaining FIPS configuration

## Why No Runtime GODEBUG?

Plugin processes are spawned by Velero and **automatically inherit** the parent's `GODEBUG=fips140=on` environment variable. No additional configuration needed in the plugin container.

## FIPS Implementation Details

Uses Go's **native FIPS 140-3 module** (different from the [OpenSSL-based golang-fips approach](https://github.com/golang-fips/go)):

- ✅ Official FIPS 140-3 certified (module A6650)
- ✅ **Pure Go implementation** - no CGO or OpenSSL dependencies
- ✅ Cross-compilation works natively (no QEMU or architecture-specific C compilers needed)
- ✅ No runtime OpenSSL dependencies
- ✅ Matches Velero's FIPS capabilities

## Why CGO_ENABLED=0?

Per the [official Go FIPS blog](https://go.dev/blog/fips140), GOFIPS140 is:

> "written in pure Go (and Go assembly) rather than using cgo"

This simplifies builds and enables native cross-compilation.

## Companion PRs

- Velero FIPS support: openshift/velero#491
- Reference implementation: openshift/hypershift-oadp-plugin#236

## Testing

Build and verify:
```bash
podman build -f Dockerfile.ubi -t velero-plugin-azure:fips-test .
# Binary includes FIPS module
podman run --rm velero-plugin-azure:fips-test file /plugins/velero-plugin-for-microsoft-azure
```

Runtime verification (requires Velero with FIPS):
```bash
# Deploy OADP 1.5 with Azure plugin
# Verify plugin inherits FIPS mode from Velero
oc exec -n openshift-adp deployment/velero -- env | grep GODEBUG
```

> [!Note]
> Responses generated with Claude

/cc @kaovilai